### PR TITLE
Fix: Remove incorrect npx reference in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,4 +5,3 @@ echo "Serving files from the 'development' directory."
 echo "Your browser will automatically refresh when you save changes."
 echo "Press Ctrl+C to stop the server."
 python3 -m livereload development/
-npx live-server development/


### PR DESCRIPTION
Removes the `npx live-server` command from the development start script, as the project has moved to a Python-based livereload server.

The `scripts/start.sh` file contained a redundant and outdated command for starting a development server. This change removes the incorrect npx command, leaving the correct `python3 -m livereload` command in place.