### PR TITLE
Fix: Prevent duplicate server startup in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,9 +2,3 @@
 
 # This script starts the development server by running the server.py helper script.
 python3 scripts/server.py
-# This script starts a live-reloading server for developing the game.
-echo "Starting development server with live reload..."
-echo "Serving files from the 'development' directory."
-echo "Your browser will automatically refresh when you save changes."
-echo "Press Ctrl+C to stop the server."
-python3 -m livereload development/


### PR DESCRIPTION
The `scripts/start.sh` script was incorrectly configured to start two development servers simultaneously. This caused the `livereload` script to be injected twice into the HTML, resulting in a JavaScript syntax error ("Identifier has already been declared") that prevented the application from loading.

This commit removes the redundant server startup command, ensuring that only one server instance is launched.